### PR TITLE
Fix async contextmanager session

### DIFF
--- a/pysabnzbd/__init__.py
+++ b/pysabnzbd/__init__.py
@@ -15,7 +15,7 @@ class SabnzbdApi(object):
     async def call(self, params):
         api_params = {**self.default_params, **params}
         try:
-            with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession() as session:
                 resp = await session.get(self.api_url, params=api_params)
                 data = await resp.json()
                 if data.get('status', True) is False:


### PR DESCRIPTION
`aiohttp`'s ClientSession contextmanager needs to be called with the `async with` syntax. See https://aiohttp.readthedocs.io/en/stable/client_quickstart.html for more info.

It was causing errors such as this one: https://github.com/home-assistant/home-assistant/issues/13032#issuecomment-372002134