### PR TITLE
Change default web root to sabnzbd

### DIFF
--- a/pysabnzbd/__init__.py
+++ b/pysabnzbd/__init__.py
@@ -11,7 +11,7 @@ class SabnzbdApi(object):
         if web_root is not None:
             web_root = '{}/'.format(web_root.strip('/'))
         else:
-            web_root = ''
+            web_root = 'sabnzbd'
 
         self.queue = {}
         self._api_url = '{}/{}{}'.format(base_url.rstrip('/'), web_root, 'api')


### PR DESCRIPTION
Sabnzbd uses /sabnzbd/ as the default `web_root`, so it would make sense to change the default behaviour of this library to reflect that. Additionally, an empty `web_root` will error out because it produces a malformed url: `http://hostname:8080//api` as opposed to the expected `http://hostname:8080/api`. For reference, the default sabnzbd api url is `http://hostname:8080/sabnzbd/api`.