### PR TITLE
Drop async-timeout and loop

### DIFF
--- a/pysabnzbd/__init__.py
+++ b/pysabnzbd/__init__.py
@@ -17,7 +17,6 @@ class SabnzbdApi(object):
         self._timeout = timeout
 
         if session is None:
-            loop = asyncio.get_event_loop()
             self._session = ClientSession()
             self._cleanup_session = True
         else:

--- a/pysabnzbd/__init__.py
+++ b/pysabnzbd/__init__.py
@@ -18,7 +18,7 @@ class SabnzbdApi(object):
 
         if session is None:
             loop = asyncio.get_event_loop()
-            self._session = ClientSession(loop=loop)
+            self._session = ClientSession()
             self._cleanup_session = True
         else:
             self._session = session

--- a/pysabnzbd/__init__.py
+++ b/pysabnzbd/__init__.py
@@ -1,7 +1,5 @@
-import aiohttp
+from aiohttp import ClientError, ClientSession, ClientTimeout
 import asyncio
-
-from async_timeout import timeout
 
 
 class SabnzbdApi(object):
@@ -20,7 +18,7 @@ class SabnzbdApi(object):
 
         if session is None:
             loop = asyncio.get_event_loop()
-            self._session = aiohttp.ClientSession(loop=loop)
+            self._session = ClientSession(loop=loop)
             self._cleanup_session = True
         else:
             self._session = session
@@ -38,14 +36,17 @@ class SabnzbdApi(object):
 
         p = {**self._default_params, **params}
         try:
-            async with timeout(self._timeout, loop=self._session.loop):
-                async with self._session.get(self._api_url, params=p) as resp:
-                    data = await resp.json()
-                    if data.get('status', True) is False:
-                        self._handle_error(data, params)
-                    else:
-                        return data
-        except aiohttp.ClientError:
+            resp = await self._session.get(
+                self._api_url,
+                params=p,
+                timeout=ClientTimeout(self._timeout)
+            )
+            data = await resp.json()
+            if data.get('status', True) is False:
+                self._handle_error(data, params)
+            else:
+                return data
+        except ClientError:
             raise SabnzbdApiException('Unable to communicate with Sabnzbd API')
         except asyncio.TimeoutError:
             raise SabnzbdApiException('SABnzbd API request timed out')

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,13 @@ from setuptools import setup
 setup(
     name='pysabnzbd',
     packages=['pysabnzbd'],
-    version='1.1.0',
+    version='1.1.1',
     description='Python wrapper for SABnzbd API',
     author='Jerad Meisner',
     author_email='jerad.meisner@gmail.com',
     url='https://github.com/jeradM/pysabnzbd',
     download_url='https://github.com/jeradM/pysabnzbd/archive/1.1.0.tar.gz',
     keywords=['SABnzbd'],
-    install_requires=[
-        'aiohttp',
-        'async-timeout'
-    ],
+    install_requires=["aiohttp>=3.6.1,<4.0"],
     classifiers=[]
 )


### PR DESCRIPTION
The use of `async_timeout` context and `loop` arguement in `aiohttp.ClientSession` has been deprecated. This PR addresses this and sets minimum requirements.